### PR TITLE
More dlt features

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Production traces                 Hugging Face                    Hugging Face
 
 ```bash
 # Install dependencies
-pip install dlt[filesystem,hf] litellm datasets
+pip install "dlt[filesystem,hf,duckdb]" litellm datasets
 
 # Install Distil Labs CLI
 curl -fsSL https://cli-assets.distillabs.ai/install.sh | sh
@@ -112,7 +112,7 @@ Distil Labs only needs a small number of clean, representative examples as a see
 The most important output is `unstructured.jsonl`, which contains all 1,107 original production traces. This is what grounds the synthetic data generation: the Distil Labs pipeline feeds these traces to the teacher model as domain context, so the generated training examples reflect the vocabulary, phrasing, and edge cases of your real traffic rather than the model's generic priors.
 
 ```bash
-python stage2-prepare-distil-labs-data.py --input my-org/massive_iot_2026_03_02_09_16_28
+python stage2-prepare-distil-labs-data.py --input dlthub/massive_iot_2026_03_03_11_05_35
 ```
 
 This produces the `finetuning-data/` directory ready for upload:

--- a/stage1-preprocess-data.py
+++ b/stage1-preprocess-data.py
@@ -20,13 +20,13 @@ Usage:
 """
 
 import argparse
-import json
 import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 
 import dlt
+from dlt.sources.filesystem import filesystem, read_jsonl
 
 SLOT_PATTERN = re.compile(r"\[(\w+)\s*:\s*([^\]]+)\]")
 
@@ -47,51 +47,44 @@ def convert_row(row: dict) -> dict:
                     "type": "function",
                     "function": {
                         "name": row["intent"],
-                        "arguments": json.dumps(parse_arguments(row["annot_utt"])),
+                        "arguments": parse_arguments(row["annot_utt"]),
                     },
                 }
             ],
         },
     ]
-    return {
-        "messages": json.dumps(messages),
+    yield {
+        "messages": messages,
         "scenario": row["scenario"],
         "partition": row["partition"],
     }
-
-
-@dlt.resource(write_disposition="replace")
-def massive_traces(input_path: Path, scenario: str):
-    """Read and convert MASSIVE JSONL rows for a given scenario."""
-    with open(input_path) as f:
-        for line in f:
-            if not line.strip():
-                continue
-            row = json.loads(line)
-            if row["scenario"] != scenario:
-                continue
-            yield convert_row(row)
 
 
 def main(input_path: Path, scenario: str, hf_namespace: str):
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d-%H-%M-%S")
     dataset_name = f"massive_{scenario}_{timestamp}".replace("-", "_")
 
-    bucket_url = f"hf://datasets/{hf_namespace}"
+    dlt.secrets["bucket_url"] = f"hf://datasets/{hf_namespace}"
 
     pipeline = dlt.pipeline(
         pipeline_name="massive_traces",
-        destination=dlt.destinations.filesystem(bucket_url=bucket_url),
+        destination="filesystem",
         dataset_name=dataset_name,
     )
 
     print(f"Processing scenario '{scenario}' from {input_path}")
-    print(f"Uploading to {bucket_url}/{dataset_name}")
+    print(f"Uploading to {dlt.secrets.get('bucket_url')}/{dataset_name}")
 
-    load_info = pipeline.run(
-        massive_traces(input_path, scenario),
-        dataset_name=dataset_name,
-    )
+    resource = (
+        filesystem(bucket_url=str(input_path.parent), file_glob=input_path.name)
+        | read_jsonl()
+    ).with_name("massive_traces")
+
+    resource.apply_hints(write_disposition="replace", columns={"messages": {"data_type": "json"}})
+    resource.add_filter(lambda row: row["scenario"] == scenario)
+    resource.add_yield_map(convert_row)
+
+    load_info = pipeline.run(resource)
 
     print(load_info)
     print(f"\nDataset: https://huggingface.co/datasets/{hf_namespace}/{dataset_name}")

--- a/stage1-preprocess-data.py
+++ b/stage1-preprocess-data.py
@@ -84,9 +84,9 @@ def main(input_path: Path, scenario: str, hf_namespace: str):
     resource.add_filter(lambda row: row["scenario"] == scenario)
     resource.add_yield_map(convert_row)
 
-    load_info = pipeline.run(resource)
+    pipeline.run(resource)
 
-    print(load_info)
+    print(pipeline.last_trace)
     print(f"\nDataset: https://huggingface.co/datasets/{hf_namespace}/{dataset_name}")
 
 

--- a/stage2-prepare-distil-labs-data.py
+++ b/stage2-prepare-distil-labs-data.py
@@ -22,8 +22,8 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import dlt
 import litellm
-from datasets import load_dataset
 
 # ── Constants ────────────────────────────────────────────────────────
 
@@ -96,20 +96,20 @@ def parse_arguments(fc: dict) -> dict:
 # ── Stage functions ──────────────────────────────────────────────────
 
 
-def load_inputs(input_dataset: str, job_description: Path) -> tuple[dict, list[dict]]:
+def load_inputs(input_dataset: str) -> list[dict]:
     """Stage 1: Load the function schema and input dataset from Hugging Face."""
     print("Stage 1: Load inputs")
 
-    with open(job_description) as f:
-        job_desc = json.load(f)
-    schema = {t["function"]["name"]: t["function"] for t in job_desc["tools"]}
-    print(f"  Schema: {len(schema)} functions from {job_description}")
-
-    ds = load_dataset(input_dataset, split="train")
-    all_rows = [normalize_row(dict(row)) for row in ds]
+    hf_namespace, dataset_name = input_dataset.split("/", 1)
+    dlt.secrets["bucket_url"] = f"hf://datasets/{hf_namespace}"
+    p = dlt.pipeline(
+        destination="filesystem",
+        dataset_name=dataset_name,
+    )
+    all_rows = [normalize_row(row) for row in p.dataset().massive_traces.df().to_dict("records")]
     print(f"  Input:  {len(all_rows)} examples from {input_dataset}")
 
-    return schema, all_rows
+    return all_rows
 
 
 def stratified_sample(all_rows: list[dict], rng: random.Random) -> list[dict]:
@@ -148,7 +148,11 @@ def get_quality_scores(row: dict, schema: dict, model: str) -> dict:
                 temperature=0.0,
                 max_tokens=256,
             )
-            scores = json.loads(resp.choices[0].message.content.strip())
+            result = resp.choices[0].message.content.strip()
+            # Strip markdown code fences (e.g. ```json ... ```)
+            if result.startswith("```"):
+                result = result.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+            scores = json.loads(result)
             return {
                 "inference_score": int(scores["inference_score"]),
                 "coherence_score": int(scores["coherence_score"]),
@@ -252,7 +256,12 @@ def write_outputs(
 def main(input_dataset: str, job_description: Path, output_dir: Path, seed: int = SEED, model: str = DEFAULT_MODEL):
     rng = random.Random(seed)
 
-    schema, all_rows = load_inputs(input_dataset, job_description)
+    with open(job_description) as f:
+        job_desc = json.load(f)
+    schema = {t["function"]["name"]: t["function"] for t in job_desc["tools"]}
+    print(f"  Schema: {len(schema)} functions from {job_description}")
+
+    all_rows = load_inputs(input_dataset)
     sampled = stratified_sample(all_rows, rng)
     annotated = annotate_rows(sampled, schema, model)
     filtered = filter_by_quality(annotated, MIN_SCORE)


### PR DESCRIPTION
In this PR, I added a few more dlt features to the demo, for example:

- We use the built-in filesystem source so we don’t have to implement custom file-reading logic.
- We use apply_hints to change the column type and avoid unpacking nested data.
- We use add_filter to filter for the required scenario.
- We use add_yield_map to transform the data into the required format.

In the second stage, we use pipeline.dataset(). In this case, it may seem unnecessary, but in practice it opens up many possibilities for operating on data, transforming it with Ibis, and reading metadata.

I tried to avoid significant changes and kept the original demo logic intact. While we could make it more production-ready from a data engineering standpoint, the intended audience seems to be ML engineers and data scientists.

It also includes a small fix: the OpenAI model returns the response in the following format:
```
/`/`/`json 
{ ... }
/`/`/`
```
So I had to add a couple of lines to strip the extra characters.